### PR TITLE
change markdown renderer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+markdown: GFM


### PR DESCRIPTION
Default Markdown renderer for Pages wasn't rendering tables properly. It looked like raw Markdown table text. I changed the renderer from the default to GFM (GitHub Flavoured Markdown). Tested working when I change the deploy branch to `deploy`. Merging changes back to `main` and changing deploy branch back to `main` so Emma S. can continue working with original workflow.

followed fix from here: https://github.com/orgs/community/discussions/23945